### PR TITLE
Update json-rpc.php

### DIFF
--- a/json-rpc.php
+++ b/json-rpc.php
@@ -264,11 +264,12 @@ function handle_json_rpc($object, $csrf = NULL) {
             echo json_encode($response);
         } else {
             $exist = in_array($method, $methods);
-            if ($exist) {
+             if ($exist) {
                 $method_object = new ReflectionMethod($class, $method);
-                $num_expect = $method_object->getNumberOfParameters();
-                $num_expect2 = $method_object->getNumberOfRequiredParameters();
-                $can_call = $num_got == $num_expect || $num_got == $num_expect2;
+                $max_expect = $method_object->getNumberOfParameters();
+                $min_expect= $method_object->getNumberOfRequiredParameters();
+                $is_variadic = $method_object->isVariadic();
+                $can_call = ($num_got <= $max_expect || $is_variadic) && $num_got >= $min_expect;
             } else {
                 $can_call = false;
             }


### PR DESCRIPTION
@jcubic further to our discussion,
I changed to add support for function with multiple optional parameters, and for variadic functions.

**Example**

Function with multiple optional parameters
~~~php
public function optional($required, $optional1 = 'null', $optional2 = 'null'){
    return 'Required: ' . $required . ', Optional1: ' . $optional1 . ', Optional2: ' . $optional2;
}
~~~
before changes with command `term> optional firstValue secondValue`
~~~
[RPC] Wrong number of parameters in `optional' method. Got 2 expect 3
~~~
because `$num_got == $num_expect || $num_got == $num_expect2;` expects in this case either 1 or 3,

but after changing to `$num_got <= $max_expect && $num_got >= $min_expect;` result is
~~~
Required: firstValue, Optional: secondValue
~~~

**Example** of another edge case, **Variadic Functions**.
~~~php
public function variadic(...$parameters){
    return implode(' ',$parameters);
}
~~~
so although it's counted as an optional parameter and it will not be an issue if omitted, it is still only considered one parameter and will throw an error when supplied with two, i.e. with command `term> variadic firstValue secondValue` before fix
~~~
[RPC] Wrong number of parameters in `variadic' method. Got 2 expect 1
~~~
but after adding this check `($num_got <= $max_expect || $is_variadic) && $num_got >= $min_expect;` note the **|| $is_variadic**, the result is as follows
~~~
firstValue secondValue
~~~


Thanks